### PR TITLE
Remove minimal investment per user

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ allOpen {
 }
 
 group = "com.ampnet"
-version = "0.10.0"
+version = "0.10.1"
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {

--- a/src/main/kotlin/com/ampnet/walletservice/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/ampnet/walletservice/exception/ErrorCode.kt
@@ -31,7 +31,6 @@ enum class ErrorCode(val categoryCode: String, var specificCode: String, var mes
     PRJ_MISSING("07", "01", "Non existing project"),
     PRJ_DATE_EXPIRED("07", "03", "Project has expired"),
     PRJ_MAX_PER_USER("07", "04", "User has exceeded max funds per project"),
-    PRJ_MIN_PER_USER("07", "05", "Funding is below project minimum"),
     PRJ_MAX_FUNDS("07", "06", "Project has reached expected funding"),
     PRJ_NOT_ACTIVE("07", "07", "Project is not active"),
     PRJ_MISSING_PRIVILEGE("07", "11", "User is missing a privilege for project"),

--- a/src/main/kotlin/com/ampnet/walletservice/service/impl/ProjectInvestmentServiceImpl.kt
+++ b/src/main/kotlin/com/ampnet/walletservice/service/impl/ProjectInvestmentServiceImpl.kt
@@ -97,11 +97,6 @@ class ProjectInvestmentServiceImpl(
                 "User can invest max ${project.maxPerUser.toEurAmount()}"
             )
         }
-        if (amount < project.minPerUser) {
-            throw InvalidRequestException(
-                ErrorCode.PRJ_MIN_PER_USER, "User has to invest at least ${project.minPerUser.toEurAmount()}"
-            )
-        }
     }
 
     private fun verifyUserHasEnoughFunds(hash: String, amount: Long) {

--- a/src/test/kotlin/com/ampnet/walletservice/service/ProjectInvestmentServiceTest.kt
+++ b/src/test/kotlin/com/ampnet/walletservice/service/ProjectInvestmentServiceTest.kt
@@ -71,25 +71,6 @@ class ProjectInvestmentServiceTest : JpaServiceTestBase() {
     }
 
     @Test
-    fun mustThrowExceptionIfInvestmentAmountIsBelowMinimum() {
-        suppose("Project service will return project") {
-            Mockito.`when`(
-                mockedProjectService.getProject(projectUuid)
-            ).thenReturn(getProjectResponse(projectUuid, userUuid, organizationUuid))
-        }
-        suppose("Request amount is below project minimum") {
-            testContext.investmentRequest = ProjectInvestmentRequest(projectUuid, createUserPrincipal(userUuid), 10)
-        }
-
-        verify("Service will throw exception investment below project minimum") {
-            val exception = assertThrows<InvalidRequestException> {
-                projectInvestmentService.generateInvestInProjectTransaction(testContext.investmentRequest)
-            }
-            assertThat(exception.errorCode).isEqualTo(ErrorCode.PRJ_MIN_PER_USER)
-        }
-    }
-
-    @Test
     fun mustThrowExceptionIfInvestmentAmountIsAboveMaximum() {
         suppose("Project service will return project") {
             Mockito.`when`(


### PR DESCRIPTION
The logic was wrong because after the user invests the first minimal investment, it can reinvest any given amount.